### PR TITLE
Usability tweaks and minor cleanup

### DIFF
--- a/Sources/Flow/Model/Node.swift
+++ b/Sources/Flow/Model/Node.swift
@@ -15,7 +15,8 @@ public struct Node: Equatable {
     public var position: CGPoint
     public var inputs: [Port]
     public var outputs: [Port]
-
+    
+    @_disfavoredOverload
     public init(name: String, position: CGPoint = .zero, inputs: [Port] = [], outputs: [Port] = []) {
         self.name = name
         self.position = position

--- a/Sources/Flow/Model/Node.swift
+++ b/Sources/Flow/Model/Node.swift
@@ -2,10 +2,10 @@
 
 import Foundation
 
-/// Nodes are identified by index in `Patch.nodes`
+/// Nodes are identified by index in `Patch.nodes`.
 public typealias NodeIndex = Int
 
-/// Nodes are identified by index in `Patch.nodes`
+/// Nodes are identified by index in `Patch.nodes`.
 ///
 /// Using indices as IDs has proven to be easy and fast for our use cases. The `Patch` should be
 /// generated from your own data model, not used as your data model, so there isn't a requirement that
@@ -37,7 +37,7 @@ public struct Node: Equatable {
         return result
     }
 
-    /// Calculates the boudning rectangle for a node.
+    /// Calculates the bounding rectangle for a node.
     public func rect(layout: LayoutConstants) -> CGRect {
         let maxio = CGFloat(max(inputs.count, outputs.count))
         let size = CGSize(width: layout.nodeWidth, height: CGFloat(maxio * 30 + layout.nodeTitleHeight))

--- a/Sources/Flow/Model/Patch.swift
+++ b/Sources/Flow/Model/Patch.swift
@@ -9,8 +9,8 @@ import Foundation
 /// as well as a function to update your data model when the `Patch` changes.
 /// Use SwiftUI's onChange(of:) to monitor changes.
 public struct Patch: Equatable {
-    var nodes: [Node]
-    var wires: Set<Wire>
+    public var nodes: [Node]
+    public var wires: Set<Wire>
 
     public init(nodes: [Node], wires: Set<Wire>) {
         self.nodes = nodes

--- a/Sources/Flow/Model/Patch.swift
+++ b/Sources/Flow/Model/Patch.swift
@@ -7,7 +7,7 @@ import Foundation
 ///
 /// Write a function to generate a `Patch` from your own data model
 /// as well as a function to update your data model when the `Patch` changes.
-/// Use SwiftUI's onChange(of:) to monitor changes.
+/// Use SwiftUI's `onChange(of:)` to monitor changes.
 public struct Patch: Equatable {
     public var nodes: [Node]
     public var wires: Set<Wire>
@@ -48,9 +48,11 @@ public struct Patch: Equatable {
 
     /// Recursive layout.
     ///
-    /// Returns height of all nodes in subtree.
+    /// - Returns: Height of all nodes in subtree.
     @discardableResult
-    public mutating func recursiveLayout(nodeIndex: NodeIndex, point: CGPoint, layout: LayoutConstants = LayoutConstants()) -> CGFloat {
+    public mutating func recursiveLayout(nodeIndex: NodeIndex,
+                                         point: CGPoint,
+                                         layout: LayoutConstants = LayoutConstants()) -> CGFloat {
         nodes[nodeIndex].position = point
 
         // XXX: super slow

--- a/Sources/Flow/Model/Port.swift
+++ b/Sources/Flow/Model/Port.swift
@@ -2,10 +2,10 @@
 
 import Foundation
 
-/// Ports are identified by index within a node
+/// Ports are identified by index within a node.
 public typealias PortIndex = Int
 
-/// Uniquely identfies an input by indices.
+/// Uniquely identifies an input by indices.
 public struct InputID: Equatable, Hashable {
     public let nodeIndex: NodeIndex
     public let portIndex: PortIndex
@@ -20,7 +20,7 @@ public struct InputID: Equatable, Hashable {
     }
 }
 
-/// Uniquely identfies an output by indices.
+/// Uniquely identifies an output by indices.
 public struct OutputID: Equatable, Hashable {
     public let nodeIndex: NodeIndex
     public let portIndex: PortIndex
@@ -38,7 +38,7 @@ public struct OutputID: Equatable, Hashable {
 /// Support for different types of connections.
 ///
 /// Some graphs have different types of ports which can't be
-/// connected to eachother. Here we offer two common types
+/// connected to each other. Here we offer two common types
 /// as well as a custom option for your own types. XXX: not implemented yet
 public enum PortType: Equatable, Hashable {
     case control
@@ -53,7 +53,7 @@ public struct Port: Equatable, Hashable {
 
     /// Initialize the port with a name and type
     /// - Parameters:
-    ///   - name: Descriptive abel of the port
+    ///   - name: Descriptive label of the port
     ///   - type: Type of port
     public init(name: String, type: PortType = .signal) {
         self.name = name

--- a/Sources/Flow/Model/Port.swift
+++ b/Sources/Flow/Model/Port.swift
@@ -7,8 +7,8 @@ public typealias PortIndex = Int
 
 /// Uniquely identfies an input by indices.
 public struct InputID: Equatable, Hashable {
-    var nodeIndex: NodeIndex
-    var portIndex: PortIndex
+    public let nodeIndex: NodeIndex
+    public let portIndex: PortIndex
 
     /// Initialize an input
     /// - Parameters:
@@ -22,8 +22,8 @@ public struct InputID: Equatable, Hashable {
 
 /// Uniquely identfies an output by indices.
 public struct OutputID: Equatable, Hashable {
-    var nodeIndex: NodeIndex
-    var portIndex: PortIndex
+    public let nodeIndex: NodeIndex
+    public let portIndex: PortIndex
 
     /// Initialize an output
     /// - Parameters:
@@ -48,8 +48,8 @@ public enum PortType: Equatable, Hashable {
 
 /// Information for either an input or an output.
 public struct Port: Equatable, Hashable {
-    var name: String
-    var type: PortType
+    public let name: String
+    public let type: PortType
 
     /// Initialize the port with a name and type
     /// - Parameters:

--- a/Sources/Flow/Model/Wire.swift
+++ b/Sources/Flow/Model/Wire.swift
@@ -9,8 +9,8 @@ import Foundation
 /// a single node. Our data model allows arbitrary connections, though we don't yet support
 /// editing of arbitrary connection graphs (an input can only have one wire).
 public struct Wire: Equatable, Hashable {
-    var output: OutputID
-    var input: InputID
+    public let output: OutputID
+    public let input: InputID
 
     /// Initialize the wire with an input and output
     /// - Parameters:

--- a/Sources/Flow/Views/NodeEditor.swift
+++ b/Sources/Flow/Views/NodeEditor.swift
@@ -25,11 +25,13 @@ public struct NodeEditor: View {
     /// Called when a wire is removed.
     var wireRemoved: (Wire) -> Void
 
-    /// Initialize the patch view with a patch and a selection
+    /// Initialize the patch view with a patch and a selection.
     /// - Parameters:
-    ///   - patch: Patch to display
-    ///   - selection: set of nodes currently selected
-    ///   - moveNode: called when a node is moved
+    ///   - patch: Patch to display.
+    ///   - selection: Set of nodes currently selected.
+    ///   - moveNode: Called when a node is moved.
+    ///   - wireAdded: Called when a wire is added.
+    ///   - wireRemoved: Called when a wire is removed.
     public init(patch: Binding<Patch>,
                 selection: Binding<Set<NodeIndex>>,
                 nodeMoved: @escaping (NodeIndex, CGPoint) -> Void = { (_,_) in },

--- a/Tests/FlowTests/LayoutTests.swift
+++ b/Tests/FlowTests/LayoutTests.swift
@@ -1,3 +1,4 @@
+// Copyright AudioKit. All Rights Reserved. Revision History at http://github.com/AudioKit/Flow/
 
 import Flow
 import XCTest

--- a/Tests/FlowTests/NodeEditorTests.swift
+++ b/Tests/FlowTests/NodeEditorTests.swift
@@ -1,3 +1,5 @@
+// Copyright AudioKit. All Rights Reserved. Revision History at http://github.com/AudioKit/Flow/
+
 @testable import Flow
 import XCTest
 

--- a/Tests/FlowTests/NodeTests.swift
+++ b/Tests/FlowTests/NodeTests.swift
@@ -1,0 +1,16 @@
+// Copyright AudioKit. All Rights Reserved. Revision History at http://github.com/AudioKit/Flow/
+
+@testable import Flow
+import XCTest
+
+final class NodeTests: XCTestCase {
+    
+    /// This test ensures disambiguation for identical `Node` init signature overloads
+    /// where inputs and outputs are empty.
+    /// It will throw a compiler error if it cannot determine which to use.
+    /// No logic testing is necessary here.
+    func testNodeInitDisambiguation() throws {
+        _ = Node(name: "Name")
+        _ = Node(name: "Name", position: .zero, inputs: [], outputs: [])
+    }
+}


### PR DESCRIPTION
Commit messages are self-explanatory.

- Some struct properties needed to be made public in order to introspect them on Patch change callbacks etc.
- Added disambiguation for `Node` inits where inputs and outputs parameters are passed as empty array literals.
- Also did a little cleanup and fixed spelling mistakes.