### PR TITLE
NodeEditor handlers, style, port type, layout improvements

### DIFF
--- a/Demo/Shared/ContentView.swift
+++ b/Demo/Shared/ContentView.swift
@@ -16,7 +16,7 @@ func simplePatch() -> Patch {
                      Wire(from: OutputID(4, 0), to: InputID(5, 0))])
 
     var patch = Patch(nodes: nodes, wires: wires)
-    patch.recursiveLayout(nodeIndex: 5, point: CGPoint(x: 800, y: 50))
+    patch.recursiveLayout(nodeIndex: 5, at: CGPoint(x: 800, y: 50))
     return patch
 }
 

--- a/Flow.playground/Contents.swift
+++ b/Flow.playground/Contents.swift
@@ -28,6 +28,15 @@ struct FlowDemoView: View {
 
     public var body: some View {
         NodeEditor(patch: $patch, selection: $selection)
+            .onNodeMoved { index, location in
+                print("Node at index \(index) moved to \(location)")
+            }
+            .onWireAdded { wire in
+                print("Added wire: \(wire)")
+            }
+            .onWireRemoved { wire in
+                print("Removed wire: \(wire)")
+            }
     }
 }
 

--- a/Flow.playground/Contents.swift
+++ b/Flow.playground/Contents.swift
@@ -5,11 +5,14 @@ import SwiftUI
 func simplePatch() -> Patch {
     let midiSource = Node(name: "MIDI source",
                           outputs: [
-                            Port(name: "out ch. 1", type: .custom("MIDI")),
-                            Port(name: "out ch. 2", type: .custom("MIDI"))
+                            Port(name: "out ch. 1", type: .midi),
+                            Port(name: "out ch. 2", type: .midi)
                           ])
     let generator = Node(name: "generator",
-                         inputs: [Port(name: "in", type: .custom("MIDI"))],
+                         inputs: [
+                            Port(name: "midi in", type: .midi),
+                            Port(name: "CV in", type: .control)
+                         ],
                          outputs: [Port(name: "out")])
     let processor = Node(name: "processor", inputs: ["in"], outputs: ["out"])
     let mixer = Node(name: "mixer", inputs: ["in1", "in2"], outputs: ["out"])
@@ -39,8 +42,9 @@ struct FlowDemoView: View {
     public var body: some View {
         NodeEditor(patch: $patch, selection: $selection)
             .nodeColor(.black)
+            .portColor(for: .control, .gray)
             .portColor(for: .signal, Gradient(colors: [.yellow, .blue]))
-            .portColor(for: .custom("MIDI"), .red)
+            .portColor(for: .midi, .red)
         
             .onNodeMoved { index, location in
                 print("Node at index \(index) moved to \(location)")

--- a/Flow.playground/Contents.swift
+++ b/Flow.playground/Contents.swift
@@ -31,7 +31,7 @@ func simplePatch() -> Patch {
     ])
 
     var patch = Patch(nodes: nodes, wires: wires)
-    patch.recursiveLayout(nodeIndex: 6, point: CGPoint(x: 1000, y: 50))
+    patch.recursiveLayout(nodeIndex: 6, at: CGPoint(x: 1000, y: 50))
     return patch
 }
 
@@ -41,7 +41,7 @@ struct FlowDemoView: View {
 
     public var body: some View {
         NodeEditor(patch: $patch, selection: $selection)
-            .nodeColor(.black)
+            .nodeColor(.secondary)
             .portColor(for: .control, .gray)
             .portColor(for: .signal, Gradient(colors: [.yellow, .blue]))
             .portColor(for: .midi, .red)

--- a/Flow.playground/Contents.swift
+++ b/Flow.playground/Contents.swift
@@ -3,22 +3,32 @@ import PlaygroundSupport
 import SwiftUI
 
 func simplePatch() -> Patch {
-
-    let generator = Node(name: "generator", outputs: ["out"])
+    let midiSource = Node(name: "MIDI source",
+                          outputs: [
+                            Port(name: "out ch. 1", type: .custom("MIDI")),
+                            Port(name: "out ch. 2", type: .custom("MIDI"))
+                          ])
+    let generator = Node(name: "generator",
+                         inputs: [Port(name: "in", type: .custom("MIDI"))],
+                         outputs: [Port(name: "out")])
     let processor = Node(name: "processor", inputs: ["in"], outputs: ["out"])
     let mixer = Node(name: "mixer", inputs: ["in1", "in2"], outputs: ["out"])
     let output = Node(name: "output", inputs: ["in"])
 
-    let nodes = [generator, processor, generator, processor, mixer, output]
+    let nodes = [midiSource, generator, processor, generator, processor, mixer, output]
 
-    let wires = Set([Wire(from: OutputID(0, 0), to: InputID(1, 0)),
-                     Wire(from: OutputID(1, 0), to: InputID(4, 0)),
-                     Wire(from: OutputID(2, 0), to: InputID(3, 0)),
-                     Wire(from: OutputID(3, 0), to: InputID(4, 1)),
-                     Wire(from: OutputID(4, 0), to: InputID(5, 0))])
+    let wires = Set([
+        Wire(from: OutputID(0, 0), to: InputID(1, 0)),
+        Wire(from: OutputID(0, 1), to: InputID(3, 0)),
+        Wire(from: OutputID(1, 0), to: InputID(2, 0)),
+        Wire(from: OutputID(2, 0), to: InputID(5, 0)),
+        Wire(from: OutputID(3, 0), to: InputID(4, 0)),
+        Wire(from: OutputID(4, 0), to: InputID(5, 1)),
+        Wire(from: OutputID(5, 0), to: InputID(6, 0))
+    ])
 
     var patch = Patch(nodes: nodes, wires: wires)
-    patch.recursiveLayout(nodeIndex: 5, point: CGPoint(x: 800, y: 50))
+    patch.recursiveLayout(nodeIndex: 6, point: CGPoint(x: 1000, y: 50))
     return patch
 }
 
@@ -28,6 +38,10 @@ struct FlowDemoView: View {
 
     public var body: some View {
         NodeEditor(patch: $patch, selection: $selection)
+            .nodeColor(.black)
+            .portColor(for: .signal, Gradient(colors: [.yellow, .blue]))
+            .portColor(for: .custom("MIDI"), .red)
+        
             .onNodeMoved { index, location in
                 print("Node at index \(index) moved to \(location)")
             }
@@ -40,5 +54,5 @@ struct FlowDemoView: View {
     }
 }
 
-PlaygroundPage.current.setLiveView(FlowDemoView().frame(width: 1000, height: 500))
+PlaygroundPage.current.setLiveView(FlowDemoView().frame(width: 1200, height: 500))
 PlaygroundPage.current.needsIndefiniteExecution = true

--- a/README.md
+++ b/README.md
@@ -9,7 +9,6 @@ your data model when the `Patch` changes.
 
 ```swift
 func simplePatch() -> Patch {
-
     let generator = Node(name: "generator", outputs: ["out"])
     let processor = Node(name: "processor", inputs: ["in"], outputs: ["out"])
     let mixer = Node(name: "mixer", inputs: ["in1", "in2"], outputs: ["out"])
@@ -34,6 +33,15 @@ struct ContentView: View {
 
     var body: some View {
         NodeEditor(patch: $patch, selection: $selection)
+            .onNodeMoved { index, location in
+                print("Node at index \(index) moved to \(location)")
+            }
+            .onWireAdded { wire in
+                print("Added wire: \(wire)")
+            }
+            .onWireRemoved { wire in
+                print("Removed wire: \(wire)")
+            }
     }
 }
 ```

--- a/README.md
+++ b/README.md
@@ -23,7 +23,7 @@ func simplePatch() -> Patch {
                      Wire(from: OutputID(4, 0), to: InputID(5, 0))])
 
     var patch = Patch(nodes: nodes, wires: wires)
-    patch.recursiveLayout(nodeIndex: 5, point: CGPoint(x: 800, y: 50))
+    patch.recursiveLayout(nodeIndex: 5, at: CGPoint(x: 800, y: 50))
     return patch
 }
 

--- a/Sources/Flow/Flow.docc/Flow.md
+++ b/Sources/Flow/Flow.docc/Flow.md
@@ -26,7 +26,7 @@ func simplePatch() -> Patch {
                      Wire(from: OutputID(4, 0), to: InputID(5, 0))])
 
     var patch = Patch(nodes: nodes, wires: wires)
-    patch.recursiveLayout(nodeIndex: 5, point: CGPoint(x: 800, y: 50))
+    patch.recursiveLayout(nodeIndex: 5, at: CGPoint(x: 800, y: 50))
     return patch
 }
 

--- a/Sources/Flow/Flow.docc/Flow.md
+++ b/Sources/Flow/Flow.docc/Flow.md
@@ -12,7 +12,6 @@ Generate a `Patch` from your own data model. Update your data model when the `Pa
 
 ```swift
 func simplePatch() -> Patch {
-
     let generator = Node(name: "generator", outputs: ["out"])
     let processor = Node(name: "processor", inputs: ["in"], outputs: ["out"])
     let mixer = Node(name: "mixer", inputs: ["in1", "in2"], outputs: ["out"])
@@ -37,6 +36,15 @@ struct ContentView: View {
 
     var body: some View {
         NodeEditor(patch: $patch, selection: $selection)
+            .onNodeMoved { index, location in
+                print("Node at index \(index) moved to \(location)")
+            }
+            .onWireAdded { wire in
+                print("Added wire: \(wire)")
+            }
+            .onWireRemoved { wire in
+                print("Removed wire: \(wire)")
+            }
     }
 }
 ```

--- a/Sources/Flow/Helpers.swift
+++ b/Sources/Flow/Helpers.swift
@@ -4,39 +4,47 @@ import Foundation
 import SwiftUI
 
 extension String {
-    func deletingPrefix(_ prefix: String) -> String? {
+    @_disfavoredOverload
+    func removing(prefix: String) -> String? {
         guard hasPrefix(prefix) else { return nil }
         return String(dropFirst(prefix.count))
     }
 }
 
 extension CGSize {
+    @_disfavoredOverload
     var point: CGPoint {
         CGPoint(x: width, y: height)
     }
 }
 
+@_disfavoredOverload
 func + (lhs: CGPoint, rhs: CGSize) -> CGPoint {
     CGPoint(x: lhs.x + rhs.width, y: lhs.y + rhs.height)
 }
 
+@_disfavoredOverload
 func - (lhs: CGPoint, rhs: CGPoint) -> CGSize {
     CGSize(width: lhs.x - rhs.x, height: lhs.y - rhs.y)
 }
 
+@_disfavoredOverload
 func + (lhs: CGSize, rhs: CGSize) -> CGSize {
     CGSize(width: lhs.width + rhs.width, height: lhs.height + rhs.height)
 }
 
 extension CGRect {
+    @_disfavoredOverload
     var center: CGPoint {
         origin + CGSize(width: size.width / 2, height: size.height / 2)
     }
-
+    
+    @_disfavoredOverload
     func offset(by off: CGSize) -> CGRect {
         offsetBy(dx: off.width, dy: off.height)
     }
 
+    @_disfavoredOverload
     init(a: CGPoint, b: CGPoint) {
         self.init()
         origin = CGPoint(x: min(a.x, b.x), y: min(a.y, b.y))
@@ -54,6 +62,7 @@ extension CGPoint {
     }
 }
 
+@_disfavoredOverload
 func += (lhs: inout CGPoint, rhs: CGSize) {
     lhs = lhs + rhs
 }

--- a/Sources/Flow/Model/LayoutConstants.swift
+++ b/Sources/Flow/Model/LayoutConstants.swift
@@ -2,7 +2,7 @@
 
 import CoreGraphics
 
-/// Define the layout geometry of the nodes
+/// Define the layout geometry of the nodes.
 public struct LayoutConstants {
     let portSize = CGSize(width: 20, height: 20)
     let portSpacing: CGFloat = 10

--- a/Sources/Flow/Model/LayoutConstants.swift
+++ b/Sources/Flow/Model/LayoutConstants.swift
@@ -8,6 +8,7 @@ public struct LayoutConstants {
     let portSpacing: CGFloat = 10
     let nodeWidth: CGFloat = 200
     let nodeTitleHeight: CGFloat = 40
-
+    let nodeSpacing: CGFloat = 40
+    
     public init() {}
 }

--- a/Sources/Flow/Model/Node.swift
+++ b/Sources/Flow/Model/Node.swift
@@ -55,7 +55,8 @@ public struct Node: Equatable {
     /// Calculates the bounding rectangle for a node.
     public func rect(layout: LayoutConstants) -> CGRect {
         let maxio = CGFloat(max(inputs.count, outputs.count))
-        let size = CGSize(width: layout.nodeWidth, height: CGFloat(maxio * 30 + layout.nodeTitleHeight))
+        let size = CGSize(width: layout.nodeWidth,
+                          height: CGFloat((maxio * (layout.portSize.height + layout.portSpacing)) + layout.nodeTitleHeight))
 
         return CGRect(origin: position, size: size)
     }

--- a/Sources/Flow/Model/Node.swift
+++ b/Sources/Flow/Model/Node.swift
@@ -2,12 +2,12 @@
 
 import CoreGraphics
 
-/// Nodes are identified by index in `Patch.nodes`.
+/// Nodes are identified by index in `Patch/nodes``.
 public typealias NodeIndex = Int
 
-/// Nodes are identified by index in `Patch.nodes`.
+/// Nodes are identified by index in ``Patch/nodes``.
 ///
-/// Using indices as IDs has proven to be easy and fast for our use cases. The `Patch` should be
+/// Using indices as IDs has proven to be easy and fast for our use cases. The ``Patch`` should be
 /// generated from your own data model, not used as your data model, so there isn't a requirement that
 /// the indices be consistent across your editing operations (such as deleting nodes).
 public struct Node: Equatable {
@@ -21,7 +21,11 @@ public struct Node: Equatable {
     public var outputs: [Port]
     
     @_disfavoredOverload
-    public init(name: String, position: CGPoint = .zero, locked: Bool = false, inputs: [Port] = [], outputs: [Port] = []) {
+    public init(name: String,
+                position: CGPoint = .zero,
+                locked: Bool = false,
+                inputs: [Port] = [],
+                outputs: [Port] = []) {
         self.name = name
         self.position = position
         self.locked = locked
@@ -29,7 +33,11 @@ public struct Node: Equatable {
         self.outputs = outputs
     }
 
-    public init(name: String, position: CGPoint = .zero, locked: Bool = false, inputs: [String] = [], outputs: [String] = []) {
+    public init(name: String,
+                position: CGPoint = .zero,
+                locked: Bool = false,
+                inputs: [String] = [],
+                outputs: [String] = []) {
         self.name = name
         self.position = position
         self.locked = locked

--- a/Sources/Flow/Model/Patch.swift
+++ b/Sources/Flow/Model/Patch.swift
@@ -51,8 +51,9 @@ public struct Patch: Equatable {
     /// - Returns: Height of all nodes in subtree.
     @discardableResult
     public mutating func recursiveLayout(nodeIndex: NodeIndex,
-                                         point: CGPoint,
-                                         layout: LayoutConstants = LayoutConstants()) -> CGFloat {
+                                         at point: CGPoint,
+                                         layout: LayoutConstants = LayoutConstants(),
+                                         nodePadding: Bool = false) -> CGFloat {
         nodes[nodeIndex].position = point
 
         // XXX: super slow
@@ -62,13 +63,20 @@ public struct Patch: Equatable {
 
         var height: CGFloat = 0
         for wire in incomingWires {
-            let h = recursiveLayout(nodeIndex: wire.output.nodeIndex,
-                                    point: CGPoint(x: point.x - layout.nodeWidth - layout.nodeSpacing,
-                                                   y: point.y + height),
-                                    layout: layout)
-            height += h
+            let addPadding = wire == incomingWires.last
+            height = recursiveLayout(nodeIndex: wire.output.nodeIndex,
+                                     at: CGPoint(x: point.x - layout.nodeWidth - layout.nodeSpacing,
+                                                 y: point.y + height),
+                                     layout: layout,
+                                     nodePadding: addPadding)
         }
 
-        return height + nodes[nodeIndex].rect(layout: layout).height
+        let nodeHeight = nodes[nodeIndex].rect(layout: layout).height
+        
+        if nodePadding {
+            return max(height, nodeHeight)
+        } else {
+            return max(height, nodeHeight) + layout.nodeSpacing
+        }
     }
 }

--- a/Sources/Flow/Model/Patch.swift
+++ b/Sources/Flow/Model/Patch.swift
@@ -79,4 +79,33 @@ public struct Patch: Equatable {
             return max(height, nodeHeight) + layout.nodeSpacing
         }
     }
+    
+    /// Manual grid layout.
+    ///
+    /// - Parameters:
+    ///   - origin: Top-left origin coordinate.
+    ///   - columns: Array of columns each comprised of an array of node indexes.
+    ///   - layout: Layout constants.
+    public mutating func stackedLayout(at origin: CGPoint = .zero,
+                                       _ columns: [[NodeIndex]],
+                                       layout: LayoutConstants = LayoutConstants()) {
+        for column in columns.indices {
+            let nodeStack = columns[column]
+            var yOffset: CGFloat = 0
+            
+            let xPos = origin.x + (CGFloat(column) * (layout.nodeWidth + layout.nodeSpacing))
+            for nodeIndex in nodeStack {
+                nodes[nodeIndex].position = .init(
+                    x: xPos,
+                    y: origin.y + yOffset
+                )
+                
+                let nodeHeight = nodes[nodeIndex].rect(layout: layout).height
+                yOffset += nodeHeight
+                if column != columns.indices.last {
+                    yOffset += layout.nodeSpacing
+                }
+            }
+        }
+    }
 }

--- a/Sources/Flow/Model/Patch.swift
+++ b/Sources/Flow/Model/Patch.swift
@@ -63,7 +63,8 @@ public struct Patch: Equatable {
         var height: CGFloat = 0
         for wire in incomingWires {
             let h = recursiveLayout(nodeIndex: wire.output.nodeIndex,
-                                    point: CGPoint(x: point.x - layout.nodeWidth - 40, y: point.y + height),
+                                    point: CGPoint(x: point.x - layout.nodeWidth - layout.nodeSpacing,
+                                                   y: point.y + height),
                                     layout: layout)
             height += h
         }

--- a/Sources/Flow/Model/Port.swift
+++ b/Sources/Flow/Model/Port.swift
@@ -43,6 +43,7 @@ public struct OutputID: Equatable, Hashable {
 public enum PortType: Equatable, Hashable {
     case control
     case signal
+    case midi
     case custom(String)
 }
 

--- a/Sources/Flow/Views/NodeEditor+Drawing.swift
+++ b/Sources/Flow/Views/NodeEditor+Drawing.swift
@@ -127,7 +127,6 @@ extension NodeEditor {
                   style: StrokeStyle(lineWidth: 2.0, lineCap: .round))
     }
     
-    
     func gradient(for outputID: OutputID) -> Gradient {
         let portType = patch
             .nodes[outputID.nodeIndex]

--- a/Sources/Flow/Views/NodeEditor+Modifiers.swift
+++ b/Sources/Flow/Views/NodeEditor+Modifiers.swift
@@ -5,6 +5,8 @@ import SwiftUI
 // View Modifiers
 
 extension NodeEditor {
+    // MARK: - Event Handlers
+    
     /// Called when a node is moved.
     public func onNodeMoved(_ handler: @escaping NodeMovedHandler) -> Self {
         var viewCopy = self
@@ -19,9 +21,60 @@ extension NodeEditor {
         return viewCopy
     }
     
+    /// Called when a wire is removed.
     public func onWireRemoved(_ handler: @escaping WireRemovedHandler) -> Self {
         var viewCopy = self
         viewCopy.wireRemoved = handler
+        return viewCopy
+    }
+    
+    // MARK: - Style Modifiers
+    
+    /// Set the node color.
+    public func nodeColor(_ color: Color) -> Self {
+        var viewCopy = self
+        viewCopy.style.nodeColor = color
+        return viewCopy
+    }
+    
+    /// Set the port color for a port type.
+    public func portColor(for portType: PortType, _ color: Color) -> Self {
+        var viewCopy = self
+        
+        switch portType {
+        case .control:
+            viewCopy.style.controlWire.inputColor = color
+            viewCopy.style.controlWire.outputColor = color
+        case .signal:
+            viewCopy.style.signalWire.inputColor = color
+            viewCopy.style.signalWire.outputColor = color
+        case .custom(let id):
+            if viewCopy.style.customWires[id] == nil {
+                viewCopy.style.customWires[id] = .init()
+            }
+            viewCopy.style.customWires[id]?.inputColor = color
+            viewCopy.style.customWires[id]?.outputColor = color
+        }
+        
+        return viewCopy
+    }
+    
+    /// Set the port color for a port type to a gradient.
+    public func portColor(for portType: PortType, _ gradient: Gradient) -> Self {
+        var viewCopy = self
+        
+        switch portType {
+        case .control:
+            viewCopy.style.controlWire.gradient = gradient
+        case .signal:
+            viewCopy.style.signalWire.gradient = gradient
+        case .custom(let id):
+            if viewCopy.style.customWires[id] == nil {
+                viewCopy.style.customWires[id] = .init()
+            }
+            viewCopy.style.customWires[id]?.gradient = gradient
+        }
+        
         return viewCopy
     }
 }

--- a/Sources/Flow/Views/NodeEditor+Modifiers.swift
+++ b/Sources/Flow/Views/NodeEditor+Modifiers.swift
@@ -48,6 +48,9 @@ extension NodeEditor {
         case .signal:
             viewCopy.style.signalWire.inputColor = color
             viewCopy.style.signalWire.outputColor = color
+        case .midi:
+            viewCopy.style.midiWire.inputColor = color
+            viewCopy.style.midiWire.outputColor = color
         case .custom(let id):
             if viewCopy.style.customWires[id] == nil {
                 viewCopy.style.customWires[id] = .init()
@@ -68,6 +71,8 @@ extension NodeEditor {
             viewCopy.style.controlWire.gradient = gradient
         case .signal:
             viewCopy.style.signalWire.gradient = gradient
+        case .midi:
+            viewCopy.style.midiWire.gradient = gradient
         case .custom(let id):
             if viewCopy.style.customWires[id] == nil {
                 viewCopy.style.customWires[id] = .init()

--- a/Sources/Flow/Views/NodeEditor+Modifiers.swift
+++ b/Sources/Flow/Views/NodeEditor+Modifiers.swift
@@ -1,0 +1,27 @@
+// Copyright AudioKit. All Rights Reserved. Revision History at http://github.com/AudioKit/Flow/
+
+import SwiftUI
+
+// View Modifiers
+
+extension NodeEditor {
+    /// Called when a node is moved.
+    public func onNodeMoved(_ handler: @escaping NodeMovedHandler) -> Self {
+        var viewCopy = self
+        viewCopy.nodeMoved = handler
+        return viewCopy
+    }
+    
+    /// Called when a wire is added.
+    public func onWireAdded(_ handler: @escaping WireAddedHandler) -> Self {
+        var viewCopy = self
+        viewCopy.wireAdded = handler
+        return viewCopy
+    }
+    
+    public func onWireRemoved(_ handler: @escaping WireRemovedHandler) -> Self {
+        var viewCopy = self
+        viewCopy.wireRemoved = handler
+        return viewCopy
+    }
+}

--- a/Sources/Flow/Views/NodeEditor+Style.swift
+++ b/Sources/Flow/Views/NodeEditor+Style.swift
@@ -14,6 +14,9 @@ extension NodeEditor {
         /// Color used for rendering signal wires.
         public var signalWire: WireStyle = .init()
         
+        /// Color used for rendering MIDI wires.
+        public var midiWire: WireStyle = .init()
+        
         /// Colors used for rendering custom wires.
         /// Dictionary is keyed by the custom wire name.
         public var customWires: [String: WireStyle] = [:]
@@ -25,6 +28,8 @@ extension NodeEditor {
                 return isOutput ? controlWire.outputColor : controlWire.inputColor
             case .signal:
                 return isOutput ? signalWire.outputColor : signalWire.inputColor
+            case .midi:
+                return isOutput ? midiWire.outputColor : midiWire.inputColor
             case .custom(let id):
                 return isOutput ? customWires[id]?.outputColor : customWires[id]?.inputColor
             }
@@ -37,6 +42,8 @@ extension NodeEditor {
                 return controlWire.gradient
             case .signal:
                 return signalWire.gradient
+            case .midi:
+                return midiWire.gradient
             case .custom(let id):
                 return customWires[id]?.gradient
             }

--- a/Sources/Flow/Views/NodeEditor+Style.swift
+++ b/Sources/Flow/Views/NodeEditor+Style.swift
@@ -1,0 +1,69 @@
+// Copyright AudioKit. All Rights Reserved. Revision History at http://github.com/AudioKit/Flow/
+
+import SwiftUI
+
+extension NodeEditor {
+    /// Configuration used to determine rendering style of a ``NodeEditor`` instance.
+    public struct Style {
+        /// Color used for rendering nodes.
+        public var nodeColor: Color = .init(white: 0.3)
+        
+        /// Color used for rendering control wires.
+        public var controlWire: WireStyle = .init()
+        
+        /// Color used for rendering signal wires.
+        public var signalWire: WireStyle = .init()
+        
+        /// Colors used for rendering custom wires.
+        /// Dictionary is keyed by the custom wire name.
+        public var customWires: [String: WireStyle] = [:]
+        
+        /// Returns input or output port color for the specified port type.
+        public func color(for portType: PortType, isOutput: Bool) -> Color? {
+            switch portType {
+            case .control:
+                return isOutput ? controlWire.outputColor : controlWire.inputColor
+            case .signal:
+                return isOutput ? signalWire.outputColor : signalWire.inputColor
+            case .custom(let id):
+                return isOutput ? customWires[id]?.outputColor : customWires[id]?.inputColor
+            }
+        }
+        
+        /// Returns port gradient for the specified port type.
+        public func gradient(for portType: PortType) -> Gradient? {
+            switch portType {
+            case .control:
+                return controlWire.gradient
+            case .signal:
+                return signalWire.gradient
+            case .custom(let id):
+                return customWires[id]?.gradient
+            }
+        }
+    }
+}
+
+extension NodeEditor.Style {
+    /// Configuration used to determine rendering style of a ``NodeEditor`` wire type.
+    public struct WireStyle {
+        public var inputColor: Color = .cyan
+        public var outputColor: Color = .magenta
+        
+        /// Get or set the input and output colors as a `Gradient`.
+        /// Only the first and last stops will be used.
+        public var gradient: Gradient {
+            get {
+                Gradient(colors: [outputColor, inputColor])
+            }
+            set {
+                if let inputColor = newValue.stops.last?.color {
+                    self.inputColor = inputColor
+                }
+                if let outputColor = newValue.stops.first?.color{
+                    self.outputColor = outputColor
+                }
+            }
+        }
+    }
+}

--- a/Sources/Flow/Views/NodeEditor.swift
+++ b/Sources/Flow/Views/NodeEditor.swift
@@ -15,33 +15,37 @@ public struct NodeEditor: View {
 
     /// State for all gestures.
     @GestureState var dragInfo = DragInfo.none
-
+    
+    /// Node moved handler closure.
+    public typealias NodeMovedHandler = (_ index: NodeIndex,
+                                         _ location: CGPoint) -> Void
+    
     /// Called when a node is moved.
-    var nodeMoved: (NodeIndex, CGPoint) -> Void
+    var nodeMoved: NodeMovedHandler = { (_,_) in }
 
+    /// Wire added handler closure.
+    public typealias WireAddedHandler = (_ wire: Wire) -> Void
+    
     /// Called when a wire is added.
-    var wireAdded: (Wire) -> Void
-
+    var wireAdded: WireAddedHandler = { _ in }
+    
+    /// Wire removed handler closure.
+    public typealias WireRemovedHandler = (_ wire: Wire) -> Void
+    
     /// Called when a wire is removed.
-    var wireRemoved: (Wire) -> Void
+    var wireRemoved: WireRemovedHandler = { _ in }
 
     /// Initialize the patch view with a patch and a selection.
+    ///
+    /// To define event handlers, chain their view modifiers: ``onNodeMoved(_:)``, ``onWireAdded(_:)``, ``onWireRemoved(_:)``.
+    ///
     /// - Parameters:
     ///   - patch: Patch to display.
     ///   - selection: Set of nodes currently selected.
-    ///   - moveNode: Called when a node is moved.
-    ///   - wireAdded: Called when a wire is added.
-    ///   - wireRemoved: Called when a wire is removed.
     public init(patch: Binding<Patch>,
-                selection: Binding<Set<NodeIndex>>,
-                nodeMoved: @escaping (NodeIndex, CGPoint) -> Void = { (_,_) in },
-                wireAdded: @escaping (Wire) -> Void = { _ in },
-                wireRemoved: @escaping (Wire) -> Void = { _ in }) {
+                selection: Binding<Set<NodeIndex>>) {
         _patch = patch
         _selection = selection
-        self.nodeMoved = nodeMoved
-        self.wireAdded = wireAdded
-        self.wireRemoved = wireRemoved
     }
 
     /// Constants used for layout.
@@ -52,7 +56,7 @@ public struct NodeEditor: View {
 
     public var body: some View {
         Canvas { cx, size in
-
+            
             let viewport = CGRect(origin: .zero, size: size)
             cx.addFilter(.shadow(radius: 5))
 

--- a/Sources/Flow/Views/NodeEditor.swift
+++ b/Sources/Flow/Views/NodeEditor.swift
@@ -50,10 +50,10 @@ public struct NodeEditor: View {
 
     /// Constants used for layout.
     var layout = LayoutConstants()
-
-    /// Gradient used for rendering wires.
-    let wireGradient = Gradient(colors: [.magenta, .cyan])
-
+    
+    /// Configuration used to determine rendering style.
+    public var style = Style()
+    
     public var body: some View {
         Canvas { cx, size in
             

--- a/Tests/FlowTests/NodeTests.swift
+++ b/Tests/FlowTests/NodeTests.swift
@@ -4,7 +4,6 @@
 import XCTest
 
 final class NodeTests: XCTestCase {
-    
     /// This test ensures disambiguation for identical `Node` init signature overloads
     /// where inputs and outputs are empty.
     /// It will throw a compiler error if it cannot determine which to use.


### PR DESCRIPTION
- `NodeEditor` event handler closures are now view modifier methods:
  - `.onNodeMoved { }`
  - `.onWireAdded { }`
  - `.onWireRemoved { }`
- `NodeEditor` can be styled using view modifier methods:
  - `.nodeColor()` which takes a `Color` instance
  - `.portColor()` which takes a single `Color` instance, or a `Gradient` instance, to define input/output wires and port colors
- Added `.midi` case to `PortType`
- Modest improvements to `Patch` `recursiveLayout()`
- Added `Patch` `stackedLayout()` method which accepts a 2-dimentional column/row array
- Minor cleanup and housekeeping