### PR TITLE
Add modifier for view transform changes.

### DIFF
--- a/Sources/Flow/Views/NodeEditor+Modifiers.swift
+++ b/Sources/Flow/Views/NodeEditor+Modifiers.swift
@@ -27,6 +27,13 @@ public extension NodeEditor {
         viewCopy.wireRemoved = handler
         return viewCopy
     }
+    
+    /// Called when the viewing transform has changed.
+    func onTransformChanged(_ handler: @escaping TransformChangedHandler) -> Self {
+        var viewCopy = self
+        viewCopy.transformChanged = handler
+        return viewCopy
+    }
 
     // MARK: - Style Modifiers
 


### PR DESCRIPTION
In order to add new nodes at a dropped position, my client code needs to know the transform. I considered using a separate data model, but it's nice how the modifier is optional so this isn't a breaking change.