### PR TITLE
Node title bars

### DIFF
--- a/Demo/Shared/ContentView.swift
+++ b/Demo/Shared/ContentView.swift
@@ -2,10 +2,10 @@ import Flow
 import SwiftUI
 
 func simplePatch() -> Patch {
-    let generator = Node(name: "generator", outputs: ["out"])
-    let processor = Node(name: "processor", inputs: ["in"], outputs: ["out"])
-    let mixer = Node(name: "mixer", inputs: ["in1", "in2"], outputs: ["out"])
-    let output = Node(name: "output", inputs: ["in"])
+    let generator = Node(name: "generator", titleBarColor: Color.cyan, outputs: ["out"])
+    let processor = Node(name: "processor", titleBarColor: Color.red, inputs: ["in"], outputs: ["out"])
+    let mixer = Node(name: "mixer", titleBarColor: Color.gray, inputs: ["in1", "in2"], outputs: ["out"])
+    let output = Node(name: "output", titleBarColor: Color.purple, inputs: ["in"])
 
     let nodes = [generator, processor, generator, processor, mixer, output]
 

--- a/Sources/Flow/Model/LayoutConstants.swift
+++ b/Sources/Flow/Model/LayoutConstants.swift
@@ -12,6 +12,7 @@ public struct LayoutConstants {
     public var nodeSpacing: CGFloat = 40
     public var nodeTitleFont = Font.title
     public var portNameFont = Font.caption
+    public var nodeCornerRadius: CGFloat = 5
 
     public init() {}
 }

--- a/Sources/Flow/Model/Node+Layout.swift
+++ b/Sources/Flow/Model/Node+Layout.swift
@@ -8,21 +8,21 @@ public extension Node {
     func rect(layout: LayoutConstants) -> CGRect {
         let maxio = CGFloat(max(inputs.count, outputs.count))
         let size = CGSize(width: layout.nodeWidth,
-                          height: CGFloat((maxio * (layout.portSize.height + layout.portSpacing)) + layout.nodeTitleHeight))
+                          height: CGFloat((maxio * (layout.portSize.height + layout.portSpacing)) + layout.nodeTitleHeight + layout.portSpacing))
 
         return CGRect(origin: position, size: size)
     }
 
     /// Calculates the bounding rectangle for an input port (not including the name).
     func inputRect(input: PortIndex, layout: LayoutConstants) -> CGRect {
-        let y = layout.nodeTitleHeight + CGFloat(input) * (layout.portSize.height + layout.portSpacing)
+        let y = layout.nodeTitleHeight + CGFloat(input) * (layout.portSize.height + layout.portSpacing) + layout.portSpacing
         return CGRect(origin: position + CGSize(width: layout.portSpacing, height: y),
                       size: layout.portSize)
     }
 
     /// Calculates the bounding rectangle for an output port (not including the name).
     func outputRect(output: PortIndex, layout: LayoutConstants) -> CGRect {
-        let y = layout.nodeTitleHeight + CGFloat(output) * (layout.portSize.height + layout.portSpacing)
+        let y = layout.nodeTitleHeight + CGFloat(output) * (layout.portSize.height + layout.portSpacing) + layout.portSpacing
         return CGRect(origin: position + CGSize(width: layout.nodeWidth - layout.portSpacing - layout.portSize.width, height: y),
                       size: layout.portSize)
     }

--- a/Sources/Flow/Model/Node.swift
+++ b/Sources/Flow/Model/Node.swift
@@ -1,6 +1,7 @@
 // Copyright AudioKit. All Rights Reserved. Revision History at http://github.com/AudioKit/Flow/
 
 import CoreGraphics
+import SwiftUI
 
 /// Nodes are identified by index in `Patch/nodes``.
 public typealias NodeIndex = Int
@@ -13,6 +14,7 @@ public typealias NodeIndex = Int
 public struct Node: Equatable {
     public var name: String
     public var position: CGPoint
+    public var titleBarColor: Color
 
     /// Is the node position fixed so it can't be edited in the UI?
     public var locked = false
@@ -23,12 +25,14 @@ public struct Node: Equatable {
     @_disfavoredOverload
     public init(name: String,
                 position: CGPoint = .zero,
+                titleBarColor: Color = Color.clear,
                 locked: Bool = false,
                 inputs: [Port] = [],
                 outputs: [Port] = [])
     {
         self.name = name
         self.position = position
+        self.titleBarColor = titleBarColor
         self.locked = locked
         self.inputs = inputs
         self.outputs = outputs
@@ -36,12 +40,14 @@ public struct Node: Equatable {
 
     public init(name: String,
                 position: CGPoint = .zero,
+                titleBarColor: Color = Color.clear,
                 locked: Bool = false,
                 inputs: [String] = [],
                 outputs: [String] = [])
     {
         self.name = name
         self.position = position
+        self.titleBarColor = titleBarColor
         self.locked = locked
         self.inputs = inputs.map { Port(name: $0) }
         self.outputs = outputs.map { Port(name: $0) }

--- a/Sources/Flow/Views/NodeEditor+Drawing.swift
+++ b/Sources/Flow/Views/NodeEditor+Drawing.swift
@@ -124,7 +124,8 @@ extension NodeEditor {
 
             let pos = rect.origin
 
-            let bg = Path(roundedRect: rect, cornerRadius: 5)
+            let cornerRadius = layout.nodeCornerRadius
+            let bg = Path(roundedRect: rect, cornerRadius: cornerRadius)
 
             var selected = false
             switch dragInfo {
@@ -135,6 +136,26 @@ extension NodeEditor {
             }
 
             cx.fill(bg, with: selected ? selectedShading : unselectedShading)
+            
+            // Draw the title bar for the node. There seems to be
+            // no better cross-platform way to render a rectangle with the top
+            // two cornders rounded.
+            var titleBar = Path()
+            titleBar.move(to: CGPoint(x: 0, y: layout.nodeTitleHeight) + rect.origin.size)
+            titleBar.addLine(to: CGPoint(x: 0, y: cornerRadius) + rect.origin.size)
+            titleBar.addRelativeArc(center: CGPoint(x: cornerRadius, y: cornerRadius) + rect.origin.size,
+                                    radius: cornerRadius,
+                                    startAngle: .degrees(180),
+                                    delta: .degrees(90))
+            titleBar.addLine(to: CGPoint(x: layout.nodeWidth - cornerRadius, y: 0) + rect.origin.size)
+            titleBar.addRelativeArc(center: CGPoint(x: layout.nodeWidth - cornerRadius, y: cornerRadius) + rect.origin.size,
+                                    radius: cornerRadius,
+                                    startAngle: .degrees(270),
+                                    delta: .degrees(90))
+            titleBar.addLine(to: CGPoint(x: layout.nodeWidth, y: layout.nodeTitleHeight) + rect.origin.size)
+            titleBar.closeSubpath()
+            
+            cx.fill(titleBar, with: .color(node.titleBarColor))
 
             cx.draw(textCache.text(string: node.name, font: layout.nodeTitleFont, cx),
                     at: pos + CGSize(width: rect.size.width / 2, height: layout.nodeTitleHeight / 2),

--- a/Tests/FlowTests/LayoutTests.swift
+++ b/Tests/FlowTests/LayoutTests.swift
@@ -11,12 +11,12 @@ final class LayoutTests: XCTestCase {
                              outputs: [Port(name: "out", type: .signal)])
 
         XCTAssertEqual(processor.rect(layout: LayoutConstants()),
-                       CGRect(origin: processor.position, size: CGSize(width: 200, height: 70)))
+                       CGRect(origin: processor.position, size: CGSize(width: 200, height: 80)))
 
         XCTAssertEqual(processor.inputRect(input: 0, layout: LayoutConstants()),
-                       CGRect(origin: CGPoint(x: 410, y: 140), size: CGSize(width: 20, height: 20)))
+                       CGRect(origin: CGPoint(x: 410, y: 150), size: CGSize(width: 20, height: 20)))
 
         XCTAssertEqual(processor.outputRect(output: 0, layout: LayoutConstants()),
-                       CGRect(origin: CGPoint(x: 570, y: 140), size: CGSize(width: 20, height: 20)))
+                       CGRect(origin: CGPoint(x: 570, y: 150), size: CGSize(width: 20, height: 20)))
     }
 }


### PR DESCRIPTION
Adds optional title bars to nodes with customizable colors. This can be used to show different types of nodes.

<img width="1180" alt="image" src="https://user-images.githubusercontent.com/841144/203912873-7fbf7802-e29d-4f4b-9a4c-423e3e7865ae.png">
